### PR TITLE
[19번 이슈]

### DIFF
--- a/JimCarry/src/main/java/com/study/jimcarry/exception/RestExceptionHandler.java
+++ b/JimCarry/src/main/java/com/study/jimcarry/exception/RestExceptionHandler.java
@@ -67,7 +67,7 @@ public class RestExceptionHandler {
 				, message);
 		
 		return new ResponseEntity<>(new CommonResponse(HttpStatus.BAD_REQUEST.value(), message), 
-				HttpStatus.OK);
+				HttpStatus.BAD_REQUEST);
     } 
 	
 	@ExceptionHandler({CustomException.class}) 
@@ -78,7 +78,7 @@ public class RestExceptionHandler {
     	apilog.info("{} {} {} ", request.getRequestURI().substring(request.getRequestURI().lastIndexOf('/')), 
 				ex.getCode(), ex.getMessage());
 		return new ResponseEntity<>(new CommonResponse(ex.getCode(), ex.getMessage()), 
-				HttpStatus.OK);
+				HttpStatus.BAD_REQUEST);
     }
 
 	@ExceptionHandler(Exception.class)
@@ -89,7 +89,7 @@ public class RestExceptionHandler {
     	apilog.info("{} {} {}", request.getRequestURI().substring(request.getRequestURI().lastIndexOf('/')), 
 				HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage());
 		return new ResponseEntity<>(new CommonResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), 
-				ex.getMessage()), HttpStatus.OK);
+				ex.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
     }  
 
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-API 설계 기준이 있습니까? RESTful API 규칙을 위배하지 않도록 API 스펙을 조정해 주세요. #12
+HttpStatus.BAD_REQUEST상태 코드로 응답하면 되는데, HttpStatus.OK가 사용되는 이유는 무엇인가요?


### PR DESCRIPTION
HttpStatus.BAD_REQUEST상태 코드로 응답하면 되는데, HttpStatus.OK가 사용되는 이유는 무엇인가요?

HttpStatus.OK -> HttpStatus.BAD_REQUEST,
HttpStatus.INTERNAL_SERVER_ERROR로 수정

## 이슈번호
#19 

## 작업내용
HttpStatus.OK -> HttpStatus.BAD_REQUEST,
HttpStatus.INTERNAL_SERVER_ERROR로 수정

## 기타
기존에 HttpStatus.OK로 한 이유는 일단 클라이언트측에서 200으로 정상 코드로 응답을 받은 후 
CommonResponse에 제가 정의한 에러코드를 받아와서 화면측에서 처리 할 용도로 받아왔으나, 
 200보다는 해당 Exception 용도에 맞게 응답코드를 보내는 것이 맞다고 생각하여 코드를 수정 하였습니다.
